### PR TITLE
Linux x86 as target platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,15 @@ if (NE10_BUILD_UNIT_TEST)
     option(NE10_DEBUG_TRACE "Print debug trace" OFF)
 endif()
 
+if (NOT GNULINUX_X86_PLATFORM)
+  set(IS_ARM ON)
+endif()
+
 #check if proper platform is set.
-if((NOT ANDROID_PLATFORM) AND (NOT GNULINUX_PLATFORM) AND (NOT IOS_PLATFORM))
+if((NOT ANDROID_PLATFORM) AND
+   (NOT GNULINUX_PLATFORM) AND
+   (NOT GNULINUX_X86_PLATFORM) AND
+   (NOT IOS_PLATFORM))
     message(FATAL_ERROR "No platform is defined! see CMakeBuilding.txt under doc for details.")
 endif()
 
@@ -71,6 +78,9 @@ if(ANDROID_PLATFORM)
 elseif(GNULINUX_PLATFORM)
     set(CMAKE_C_FLAGS "-O2 -mthumb-interwork -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=vfp3")
     set(CMAKE_ASM_FLAGS "-mthumb-interwork -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=neon")
+elseif(GNULINUX_X86_PLATFORM)
+    set(CMAKE_C_FLAGS "-O2")
+    set(CMAKE_ASM_FLAGS "")
 elseif(IOS_PLATFORM)
     set(CMAKE_C_FLAGS "-O2 -arch armv7 -arch armv7s -mfpu=vfp3")
     set(CMAKE_ASM_FLAGS "-arch armv7 -arch armv7s -mfpu=neon")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,12 @@ endif()
 #select functionalities to be compiled
 option(NE10_ENABLE_MATH "Build math functionalities to NE10" ON)
 option(NE10_ENABLE_DSP "Build dsp functionalities to NE10" ON)
-option(NE10_ENABLE_IMGPROC "Build image processing functionalities to NE10" ON)
+if(IS_ARM)
+  option(NE10_ENABLE_IMGPROC "Build image processing functionalities to NE10" ON)
+else()
+  # These functions use NEON specific functions.
+  option(NE10_ENABLE_IMGPROC "Build image processing functionalities to NE10" OFF)
+endif()
 
 set(NE10_VERSION 10)
 

--- a/android/android_config.cmake
+++ b/android/android_config.cmake
@@ -52,6 +52,7 @@ if(ANDROID_DEMO)
 endif()
 
 execute_process(COMMAND uname -m OUTPUT_VARIABLE HOST_ARCH)
+STRING(REGEX REPLACE "\n" "" HOST_ARCH ${HOST_ARCH})
 
 if(NOT (HOST_ARCH STREQUAL "x86_64"))
   set( HOST_ARCH "x86" )

--- a/android/android_config.cmake
+++ b/android/android_config.cmake
@@ -51,6 +51,12 @@ if(ANDROID_DEMO)
     add_definitions(-DNE10_ANDROID_DEMO)
 endif()
 
+if( CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set( HOST_ARCH "x86_64" )
+else()
+  set( HOST_ARCH "x86" )
+endif()
+
 if(DEFINED ENV{ANDROID_NDK})
     if(NOT DEFINED ENV{ANDROID_API_LEVEL})
         set(ANDROID_API_LEVEL 14)
@@ -67,9 +73,9 @@ if(DEFINED ENV{ANDROID_NDK})
     set(NDK_SYSROOT_PATH "$ENV{ANDROID_NDK}/platforms/android-${ANDROID_API_LEVEL}/arch-arm/")
 
     if(APPLE)
-	set(ANDROID_TOOLCHAIN_PATH "$ENV{ANDROID_NDK}/toolchains/arm-linux-androideabi-${ARM_ANDROID_TOOLCHAIN_VERSION}/prebuilt/darwin-x86_64/bin")
+      set(ANDROID_TOOLCHAIN_PATH "$ENV{ANDROID_NDK}/toolchains/arm-linux-androideabi-${ARM_ANDROID_TOOLCHAIN_VERSION}/prebuilt/darwin-${HOST_ARCH}/bin")
     else()
-        set(ANDROID_TOOLCHAIN_PATH "$ENV{ANDROID_NDK}/toolchains/arm-linux-androideabi-${ARM_ANDROID_TOOLCHAIN_VERSION}/prebuilt/linux-x86_64/bin")
+      set(ANDROID_TOOLCHAIN_PATH "$ENV{ANDROID_NDK}/toolchains/arm-linux-androideabi-${ARM_ANDROID_TOOLCHAIN_VERSION}/prebuilt/linux-${HOST_ARCH}/bin")
     endif()
 
     #change toolchain name according to your configuration

--- a/android/android_config.cmake
+++ b/android/android_config.cmake
@@ -51,9 +51,9 @@ if(ANDROID_DEMO)
     add_definitions(-DNE10_ANDROID_DEMO)
 endif()
 
-if( CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set( HOST_ARCH "x86_64" )
-else()
+execute_process(COMMAND uname -m OUTPUT_VARIABLE HOST_ARCH)
+
+if(NOT (HOST_ARCH STREQUAL "x86_64"))
   set( HOST_ARCH "x86" )
 endif()
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -268,11 +268,20 @@ include_directories (
     ${PROJECT_SOURCE_DIR}/common
 )
 
+if (NOT GNULINUX_X86_PLATFORM)
+  set(IS_ARM ON)
+endif()
+
+if (IS_ARM)
+  set(NE10_PLATFORM_SPECIFIC_SRCS ${NE10_INTRINSIC_SRCS} ${NE10_NEON_SRCS})
+else()
+  set(NE10_PLATFORM_SPECIFIC_SRCS )
+endif()
+
 if(NE10_BUILD_STATIC OR ANDROID_PLATFORM OR IOS_DEMO)
     add_library( NE10 STATIC
         ${NE10_C_SRCS}
-        ${NE10_INTRINSIC_SRCS}
-        ${NE10_NEON_SRCS}
+        ${NE10_PLATFORM_SPECIFIC_SRCS}
         ${NE10_INIT_SRCS}
     )
     set_target_properties(NE10 PROPERTIES
@@ -290,8 +299,7 @@ if(NE10_BUILD_SHARED)
 
     add_library( NE10_shared SHARED
         ${NE10_C_SRCS}
-        ${NE10_INTRINSIC_SRCS}
-        ${NE10_NEON_SRCS}
+        ${NE10_PLATFORM_SPECIFIC_SRCS}
         ${NE10_INIT_SRCS}
     )
 
@@ -305,8 +313,7 @@ if(NE10_BUILD_SHARED)
 
     add_library( NE10_test SHARED
         ${NE10_C_SRCS}
-        ${NE10_INTRINSIC_SRCS}
-        ${NE10_NEON_SRCS}
+        ${NE10_PLATFORM_SPECIFIC_SRCS}
         ${NE10_INIT_SRCS}
     )
 

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -268,10 +268,6 @@ include_directories (
     ${PROJECT_SOURCE_DIR}/common
 )
 
-if (NOT GNULINUX_X86_PLATFORM)
-  set(IS_ARM ON)
-endif()
-
 if (IS_ARM)
   set(NE10_PLATFORM_SPECIFIC_SRCS ${NE10_INTRINSIC_SRCS} ${NE10_NEON_SRCS})
 else()

--- a/modules/dsp/NE10_init_dsp.c
+++ b/modules/dsp/NE10_init_dsp.c
@@ -31,6 +31,7 @@
 
 ne10_result_t ne10_init_dsp (ne10_int32_t is_NEON_available)
 {
+#if IS_ARM
     if (NE10_OK == is_NEON_available)
     {
         ne10_radix4_butterfly_float = ne10_radix4_butterfly_float_neon;
@@ -46,6 +47,7 @@ ne10_result_t ne10_init_dsp (ne10_int32_t is_NEON_available)
         ne10_iir_lattice_float = ne10_iir_lattice_float_neon;
     }
     else
+#endif // if IS_ARM
     {
         ne10_radix4_butterfly_float = ne10_radix4_butterfly_float_c;
         ne10_radix4_butterfly_inverse_float = ne10_radix4_butterfly_inverse_float_c;

--- a/modules/math/NE10_init_math.c
+++ b/modules/math/NE10_init_math.c
@@ -31,6 +31,7 @@
 
 ne10_result_t ne10_init_math (int is_NEON_available)
 {
+#if IS_ARM
     if (NE10_OK == is_NEON_available)
     {
         ne10_addc_float = ne10_addc_float_neon;
@@ -123,6 +124,7 @@ ne10_result_t ne10_init_math (int is_NEON_available)
         ne10_identitymat_2x2f = ne10_identitymat_2x2f_neon;
     }
     else
+#endif // IS_ARM
     {
         ne10_addc_float = ne10_addc_float_c;
         ne10_addc_vec2f = ne10_addc_vec2f_c;

--- a/samples/NE10_test.c
+++ b/samples/NE10_test.c
@@ -79,7 +79,9 @@ void test_add2 (void)
     thecst = (ne10_float32_t) rand() / RAND_MAX * 5.0f;
 
     ne10_addc_float_c (thedst1 , thesrc, thecst, 5);
+#if IS_ARM
     ne10_addc_float_neon (thedst2 , thesrc, thecst, 5);
+#endif
 }
 
 /**


### PR DESCRIPTION
To build against the x86 Linux, use this command:

cmake -DGNULINUX_X86_PLATFORM=ON ..

The pull request also contains detection whether system uses 32 or 64 bit kernel (inside the android/android_config.cmake file). This is important when building for Android, since the path to the toolchain differs in the NDK for these two.