### PR TITLE
aarch64: Enable build for aarch64 GNU Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,10 @@ if(ANDROID_PLATFORM)
     message("-- CMAKE_C_FLAGS:
     ${CMAKE_C_FLAGS}")
 elseif(GNULINUX_PLATFORM)
-    #TODO Development has been moved to android, GNULINUX_PLATFORM is not
-    # needed any more. GNULINUX_PLATFORM support needs to be removed.
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfpu=vfp3")
-    set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfpu=neon")
+    if(${NE10_TARGET_ARCH} STREQUAL "armv7")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfpu=vfp3 -funsafe-math-optimizations")
+      set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfpu=neon")
+    endif()
 elseif(IOS_PLATFORM)
     #set minimal target ios version.If not provided this option, Xcode
     #5.0.2 would generate code for iOS 7.0, which would lead runtime

--- a/GNUlinux_config.cmake
+++ b/GNUlinux_config.cmake
@@ -36,21 +36,26 @@
 #     armv7 or aarch64 (Not done yet). Defaut is armv7.
 
 set(GNULINUX_PLATFORM ON)
-#TODO: add support to AArch64 target
-set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
-set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
-set(CMAKE_ASM_COMPILER arm-linux-gnueabihf-as)
 
 if(NOT DEFINED ENV{NE10_LINUX_TARGET_ARCH})
-    set(NE10_LINUX_TARGET_ARCH "armv7")
+   set(NE10_LINUX_TARGET_ARCH "armv7")
 else()
-    if($ENV{NE10_LINUX_TARGET_ARCH} STREQUAL "aarch64")
-        message(FATAL_ERROR "aarch64 on GNU Linux support has not been done yet.")
-    endif()
-    set(NE10_LINUX_TARGET_ARCH $ENV{NE10_LINUX_TARGET_ARCH})
+   set(NE10_LINUX_TARGET_ARCH $ENV{NE10_LINUX_TARGET_ARCH})
 endif()
 
-find_program(CMAKE_AR NAMES "arm-linux-gnueabihf-ar")
+if(NE10_LINUX_TARGET_ARCH STREQUAL "armv7")
+   set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+   set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+   set(CMAKE_ASM_COMPILER arm-linux-gnueabihf-as)
+   find_program(CMAKE_AR NAMES "arm-linux-gnueabihf-ar")
+   find_program(CMAKE_RANLIB NAMES "arm-linux-gnueabihf-ranlib")
+elseif(NE10_LINUX_TARGET_ARCH STREQUAL "aarch64")
+   set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+   set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+   set(CMAKE_ASM_COMPILER aarch64-linux-gnu-as)
+   find_program(CMAKE_AR NAMES "aarch64-linux-gnu-ar")
+   find_program(CMAKE_RANLIB NAMES "aarch64-linux-gnu-ranlib")
+endif()
+
 mark_as_advanced(CMAKE_AR)
-find_program(CMAKE_RANLIB NAMES "arm-linux-gnueabihf-ranlib")
 mark_as_advanced(CMAKE_RANLIB)


### PR DESCRIPTION
Enables build configuration to be able to build Ne10
for aarch64 GNU Linux.

Eg: build instructions:
mkdir build && cd build
export NE10_LINUX_TARGET_ARCH=aarch64
cmake -DCMAKE_TOOLCHAIN_FILE=../GNUlinux_config.cmake ..
make -j6

Note: By default, NE10_LINUX_TARGET_ARCH will be set to
"armv7"

Also adds -funsafe-math-optimizations for ARMv7 GNU targets

Signed-off-by: Viswanath Puttagunta <viswanath.puttagunta@linaro.org>