### PR TITLE
NEW adds install rules to gnu/linux targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,3 +183,62 @@ endif()
 if(IOS_PLATFORM AND IOS_DEMO)
     add_subdirectory(ios)
 endif()
+
+if(GNULINUX_PLATFORM)
+	# package config
+	set(prefix ${CMAKE_INSTALL_PREFIX})
+	set(exec_prefix "\${prefix}")
+	set(libdir "\${exec_prefix}/lib${LIB_SUFFIX}")
+	set(includedir "\${prefix}/include")
+
+	configure_file(
+    	${CMAKE_CURRENT_SOURCE_DIR}/ne10.pc.in
+    	${CMAKE_CURRENT_BINARY_DIR}/ne10.pc
+	@ONLY)
+
+	install(
+   		FILES ${CMAKE_CURRENT_BINARY_DIR}/ne10.pc
+    	DESTINATION lib${LIB_SUFFIX}/pkgconfig)
+
+	# install rules
+	install( DIRECTORY inc/ 
+			 DESTINATION include/ne10 
+			 FILES_MATCHING PATTERN "*.h")
+	install( DIRECTORY common/ 
+			 DESTINATION include/ne10 
+			 FILES_MATCHING PATTERN "*.h")
+
+	if(NE10_ENABLE_DSP)
+		install( DIRECTORY modules/dsp/
+			     DESTINATION include/ne10/dsp
+		 	 	 FILES_MATCHING PATTERN "*.h")
+	endif()
+
+	if(NE10_ENABLE_MATH)
+		install( DIRECTORY modules/math/ 
+			 	 DESTINATION include/ne10/math
+		 	 	 FILES_MATCHING PATTERN "*.h")
+	endif()
+
+	if(NE10_ENABLE_IMGPROC)
+		install( DIRECTORY modules/imgproc/ 
+				 DESTINATION include/ne10/imgproc
+		 		 FILES_MATCHING PATTERN "*.h")
+	endif()
+
+	if(NE10_ENABLE_PHYSICS)
+		install( DIRECTORY modules/physics/ 
+			 	 DESTINATION include/ne10/physics
+		 	 	 FILES_MATCHING PATTERN "*.h")
+	endif()
+	# uninstall rules
+	configure_file(
+    	${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
+    	${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+	@ONLY)
+
+	add_custom_target(uninstall
+    	${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+	)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,60 +185,59 @@ if(IOS_PLATFORM AND IOS_DEMO)
 endif()
 
 if(GNULINUX_PLATFORM)
-	# package config
-	set(prefix ${CMAKE_INSTALL_PREFIX})
-	set(exec_prefix "\${prefix}")
-	set(libdir "\${exec_prefix}/lib${LIB_SUFFIX}")
-	set(includedir "\${prefix}/include")
+    # package config
+    set(prefix ${CMAKE_INSTALL_PREFIX})
+    set(exec_prefix "\${prefix}")
+    set(libdir "\${exec_prefix}/lib${LIB_SUFFIX}")
+    set(includedir "\${prefix}/include")
 
-	configure_file(
-    	${CMAKE_CURRENT_SOURCE_DIR}/ne10.pc.in
-    	${CMAKE_CURRENT_BINARY_DIR}/ne10.pc
-	@ONLY)
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/ne10.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/ne10.pc
+    @ONLY)
 
-	install(
-   		FILES ${CMAKE_CURRENT_BINARY_DIR}/ne10.pc
-    	DESTINATION lib${LIB_SUFFIX}/pkgconfig)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/ne10.pc
+    DESTINATION lib${LIB_SUFFIX}/pkgconfig)
 
-	# install rules
-	install( DIRECTORY inc/ 
-			 DESTINATION include/ne10 
-			 FILES_MATCHING PATTERN "*.h")
-	install( DIRECTORY common/ 
-			 DESTINATION include/ne10 
-			 FILES_MATCHING PATTERN "*.h")
+    # install rules
+    install(DIRECTORY inc/
+        DESTINATION include/ne10
+        FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY common/
+        DESTINATION include/ne10
+        FILES_MATCHING PATTERN "*.h")
 
-	if(NE10_ENABLE_DSP)
-		install( DIRECTORY modules/dsp/
-			     DESTINATION include/ne10/dsp
-		 	 	 FILES_MATCHING PATTERN "*.h")
-	endif()
+    if(NE10_ENABLE_DSP)
+        install(DIRECTORY modules/dsp/
+            DESTINATION include/ne10/dsp
+            FILES_MATCHING PATTERN "*.h")
+    endif()
 
-	if(NE10_ENABLE_MATH)
-		install( DIRECTORY modules/math/ 
-			 	 DESTINATION include/ne10/math
-		 	 	 FILES_MATCHING PATTERN "*.h")
-	endif()
+    if(NE10_ENABLE_MATH)
+        install(DIRECTORY modules/math/
+            DESTINATION include/ne10/math
+            FILES_MATCHING PATTERN "*.h")
+    endif()
 
-	if(NE10_ENABLE_IMGPROC)
-		install( DIRECTORY modules/imgproc/ 
-				 DESTINATION include/ne10/imgproc
-		 		 FILES_MATCHING PATTERN "*.h")
-	endif()
+    if(NE10_ENABLE_IMGPROC)
+        install(DIRECTORY modules/imgproc/
+            DESTINATION include/ne10/imgproc
+            FILES_MATCHING PATTERN "*.h")
+    endif()
 
-	if(NE10_ENABLE_PHYSICS)
-		install( DIRECTORY modules/physics/ 
-			 	 DESTINATION include/ne10/physics
-		 	 	 FILES_MATCHING PATTERN "*.h")
-	endif()
-	# uninstall rules
-	configure_file(
-    	${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
-    	${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
-	@ONLY)
+    if(NE10_ENABLE_PHYSICS)
+        install(DIRECTORY modules/physics/
+            DESTINATION include/ne10/physics
+            FILES_MATCHING PATTERN "*.h")
+    endif()
+    # uninstall rules
+    configure_file(
+        ${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+    @ONLY)
 
-	add_custom_target(uninstall
-    	${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
-	)
+    add_custom_target(uninstall
+        ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake
+    )
 endif()
-

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,32 +1,32 @@
 # http://www.vtk.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F
 
 IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
-  MESSAGE(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+    MESSAGE(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
 ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
 
 FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
 STRING(REGEX REPLACE "\n" ";" files "${files}")
 FOREACH(file ${files})
-  MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
-  IF(EXISTS "$ENV{DESTDIR}${file}")
-    EXEC_PROGRAM(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
-      OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
-      )
-    IF(NOT "${rm_retval}" STREQUAL 0)
-      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
-    ENDIF(NOT "${rm_retval}" STREQUAL 0)
-  ELSEIF(IS_SYMLINK "$ENV{DESTDIR}${file}")
-    EXEC_PROGRAM(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
-      OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
-      )
-    IF(NOT "${rm_retval}" STREQUAL 0)
-      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
-    ENDIF(NOT "${rm_retval}" STREQUAL 0)
-  ELSE(EXISTS "$ENV{DESTDIR}${file}")
-    MESSAGE(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
-  ENDIF(EXISTS "$ENV{DESTDIR}${file}")
+    MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+    IF(EXISTS "$ENV{DESTDIR}${file}")
+        EXEC_PROGRAM(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+        IF(NOT "${rm_retval}" STREQUAL 0)
+          MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+          ENDIF(NOT "${rm_retval}" STREQUAL 0)
+    ELSEIF(IS_SYMLINK "$ENV{DESTDIR}${file}")
+        EXEC_PROGRAM(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+        IF(NOT "${rm_retval}" STREQUAL 0)
+            MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+        ENDIF(NOT "${rm_retval}" STREQUAL 0)
+    ELSE(EXISTS "$ENV{DESTDIR}${file}")
+        MESSAGE(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
+    ENDIF(EXISTS "$ENV{DESTDIR}${file}")
 ENDFOREACH(file)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,32 @@
+# http://www.vtk.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F
+
+IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  MESSAGE(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt\"")
+ENDIF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+FILE(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+STRING(REGEX REPLACE "\n" ";" files "${files}")
+FOREACH(file ${files})
+  MESSAGE(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+  IF(EXISTS "$ENV{DESTDIR}${file}")
+    EXEC_PROGRAM(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    IF(NOT "${rm_retval}" STREQUAL 0)
+      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+    ENDIF(NOT "${rm_retval}" STREQUAL 0)
+  ELSEIF(IS_SYMLINK "$ENV{DESTDIR}${file}")
+    EXEC_PROGRAM(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    IF(NOT "${rm_retval}" STREQUAL 0)
+      MESSAGE(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+    ENDIF(NOT "${rm_retval}" STREQUAL 0)
+  ELSE(EXISTS "$ENV{DESTDIR}${file}")
+    MESSAGE(STATUS "File \"$ENV{DESTDIR}${file}\" does not exist.")
+  ENDIF(EXISTS "$ENV{DESTDIR}${file}")
+ENDFOREACH(file)

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -387,6 +387,8 @@ if(NE10_BUILD_STATIC OR ANDROID_PLATFORM OR IOS_DEMO)
     install(TARGETS NE10
       DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/../ios/NE10Demo/libs/)
   endif(IOS_DEMO)
+
+    install(TARGETS NE10 DESTINATION lib)
 endif()
 
 if(NE10_BUILD_SHARED)
@@ -422,4 +424,5 @@ if(NE10_BUILD_SHARED)
 
     target_link_libraries(NE10_test m)
 
+    install(TARGETS NE10_shared DESTINATION lib)
 endif()

--- a/ne10.pc.in
+++ b/ne10.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+LV_CXXFLAGS=@LV_CXXFLAGS@
+
+
+Name: ne10
+Description: Ne10: An open optimized software library project for the ARM® Architecture
+Requires:
+Version: @LIBVER@
+Libs: -L${libdir} -lne10
+Cflags: -I${includedir} ${LV_CXXFLAGS}


### PR DESCRIPTION
I rebased the pull request https://github.com/projectNe10/Ne10/pull/110 against current master and then fixed whitespace issues.

I also tested the build process with the next build steps:
```
cmake -DNE10_LINUX_TARGET_ARCH=armv7 -DGNULINUX_PLATFORM=ON ..
make
cmake -DNE10_LINUX_TARGET_ARCH=armv7 -DGNULINUX_PLATFORM=ON -DNE10_BUILD_SHARED=ON ..
make
```
And the install process with (output listed for review):
```
# make install
[ 29%] Built target NE10
[ 58%] Built target NE10_shared
[ 87%] Built target NE10_test
[ 88%] Built target NE10_test_dynamic
[ 89%] Built target NE10_test_static
[ 93%] Built target NE10_dsp_unit_test_static
[ 95%] Built target NE10_physics_unit_test_static
[ 97%] Built target NE10_math_unit_test_static
[100%] Built target NE10_imgproc_unit_test_static
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/lib/pkgconfig/ne10.pc
-- Installing: /usr/local/include/ne10
-- Installing: /usr/local/include/ne10/NE10_init.h
-- Installing: /usr/local/include/ne10/NE10_math.h
-- Installing: /usr/local/include/ne10/NE10_dsp.h
-- Installing: /usr/local/include/ne10/NE10_imgproc.h
-- Installing: /usr/local/include/ne10/NE10.h
-- Installing: /usr/local/include/ne10/NE10_types.h
-- Installing: /usr/local/include/ne10/NE10_physics.h
-- Installing: /usr/local/include/ne10/NE10_macros.h
-- Up-to-date: /usr/local/include/ne10
-- Installing: /usr/local/include/ne10/NE10_mask_table.h
-- Installing: /usr/local/include/ne10/versionheader.h
-- Installing: /usr/local/include/ne10/factor.h
-- Installing: /usr/local/include/ne10/macros.h
-- Installing: /usr/local/include/ne10/dsp
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_generic_float32.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_cplx_ops.h
-- Installing: /usr/local/include/ne10/dsp/test
-- Installing: /usr/local/include/ne10/dsp/NE10_fft.neonintrinsic.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_generic_int32.neonintrinsic.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_bfly.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_common_varibles.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_generic_int32.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft_debug_macro.h
-- Installing: /usr/local/include/ne10/dsp/NE10_fft.h
-- Installing: /usr/local/include/ne10/math
-- Installing: /usr/local/include/ne10/math/test
-- Installing: /usr/local/include/ne10/math/NE10_detmat.c.h
-- Installing: /usr/local/include/ne10/imgproc
-- Installing: /usr/local/include/ne10/imgproc/test
-- Installing: /usr/local/include/ne10/physics
-- Installing: /usr/local/include/ne10/physics/test
-- Installing: /usr/local/lib/libNE10.a
-- Installing: /usr/local/lib/libNE10.so.10
-- Installing: /usr/local/lib/libNE10.so
```