### PR TITLE
CMakeLists.txt: Remove -mthumb-interwork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(ANDROID_PLATFORM)
 
     # Adding cflags for armv7. Aarch64 does not need such flags.
     if(${NE10_TARGET_ARCH} STREQUAL "armv7")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfloat-abi=${FLOAT_ABI} -mfpu=vfp3")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb -march=armv7-a -mfloat-abi=${FLOAT_ABI} -mfpu=vfp3")
         if(NE10_ARM_HARD_FLOAT)
             # "--no-warn-mismatch" is needed for linker to suppress linker error about not all functions use VFP register to pass argument, eg.
             #   .../arm-linux-androideabi/bin/ld: error: ..../test-float.o
@@ -138,8 +138,8 @@ if(ANDROID_PLATFORM)
     ${CMAKE_C_FLAGS}")
 elseif(GNULINUX_PLATFORM)
     if("${NE10_TARGET_ARCH}" STREQUAL "armv7")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfpu=vfp3 -funsafe-math-optimizations")
-      set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -mthumb-interwork -mthumb -march=armv7-a -mfpu=neon")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb -march=armv7-a -mfpu=vfp3 -funsafe-math-optimizations")
+      set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -mthumb -march=armv7-a -mfpu=neon")
       # Turn on asm optimization for Linux on ARM v7.
       set(NE10_ASM_OPTIMIZATION on)
     endif()


### PR DESCRIPTION
This option is meaningless with aapcs ABI
which is the default for Linux and android
for armv7+ architectures

As an aside it helps in compiling with clang
where this option is absent

Signed-off-by: Khem Raj <raj.khem@gmail.com>