### PR TITLE
Drop requirement for CLA in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,6 @@
 Contributing to Project Ne10
 ====================================
 
-Before you start contributing code to this project you must sign the ARM
-Contributor License Agreement (CLA).
-
-Individuals who want to contribute their own work must sign and return an
-Individual CLA. Companies that want to contribute must sign and return a
-Corporate CLA if their employees' intellectual property has been assigned to
-the employer. Copies of the CLAs are available from the [contributing page] of
-the ARM website.
-
-For this project, ARM also requires the GitHub account name(s) associated with
-each individual contributor or the designated employees of corporate
-contributors. Only contributions originating from these accounts will be
-considered covered by the CLA. To avoid delay, you should provide the Github
-account name(s) at the same time as the signed CLA.
-
-ARM reserves the right to not accept a contribution. This may be for technical,
-commercial or legal reasons.
-
-
 Getting Started
 ---------------
 
@@ -71,7 +52,12 @@ Making Changes
 Submitting Changes
 ------------------
 
-*   Ensure we have your signed CLA.
+*   Ensure that each commit in the series has at least one `Signed-off-by:`line,
+    using your real name and email address. The names in the Signed-off-by:` and
+   `Author:` lines must match. If anyone else contributes to the commit, they
+    must also add their own `Signed-off-by:` line. By adding this line the
+    contributor certifies the contribution is made under the terms of the
+    [Developer Certificate of Origin (DCO)][DCO].
 *   Push your local changes to your fork of the repository.
 *   Submit a [pull request] to Ne10.
     *   The changes in the pull request will then undergo further review and
@@ -87,13 +73,14 @@ Submitting Changes
 
 - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-_Copyright (c) 2013-2014, ARM Limited and Contributors. All rights reserved._
+_Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved._
 
 
 [Release Notes]:                 		./doc/ReleaseNote.txt
 [Building]:                           	./doc/building.md
 [Documentation]:						http://projectne10.github.io/Ne10/doc/
 [Acknowledgements]:                     ./doc/acknowledgements.md "Contributor acknowledgements"
+[DCO]:                                  ./dco.txt
 
 [GitHub account]:               https://github.com/signup/free
 [Fork]:                         https://help.github.com/articles/fork-a-repo

--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
It is no longer necessary for contributors to send a CLA to ARM
before making contributions. Contributors must instead add a
"Signed-off-by:" line to each commit, which certifies that the
contribution is made under the Developer Certificate of Origin
(DCO).

Update CONTRIBUTING.md to reflect this new policy and add a copy of
the DCO to the repository.

Fixes projectNe10/Ne10/issues/177

Signed-off-by: David Cunado <david.cunado@arm.com>