### PR TITLE
Fix Android and iOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ elseif(IOS_PLATFORM)
     #5.0.2 would generate code for iOS 7.0, which would lead runtime
     #error when run on device with earlier iOS version.
     if(NOT MIN_IOS_VER)
-      set(MIN_IOS_VER "5.0")
+      set(MIN_IOS_VER "6.0")
     endif()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=" ${MIN_IOS_VER})
     set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -mfpu=neon -miphoneos-version-min=" ${MIN_IOS_VER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ if(ANDROID_PLATFORM)
 
     #TODO: Fine tune pic and pie flag for executable, share library and static library.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --sysroot=${NDK_SYSROOT_PATH} -pie")
+    string(APPEND CMAKE_C_FLAGS " -isysroot ${NDK_ISYSROOT_PATH}")
+    add_definitions(-D__ANDROID_API__=${ANDROID_API_LEVEL})
 
     # Adding cflags for armv7. Aarch64 does not need such flags.
     if(${NE10_TARGET_ARCH} STREQUAL "armv7")

--- a/android/android_config.cmake
+++ b/android/android_config.cmake
@@ -86,6 +86,7 @@ if(DEFINED ENV{ANDROID_NDK})
 
     #NDK_SYSROOT_PATH is used in compiler's '--sysroot' flags
     set(NDK_SYSROOT_PATH "$ENV{ANDROID_NDK}/platforms/android-${ANDROID_API_LEVEL}/arch-${ANDROID_NDK_PLATFORMS_ARCH_SUFFIX}/")
+    set(NDK_ISYSROOT_PATH "$ENV{ANDROID_NDK}/sysroot -I$ENV{ANDROID_NDK}/sysroot/usr/include/${ANDROID_NDK_TOOLCHAIN_CROSS_PREFIX}")
 
     if(APPLE)
         #TODO: Check whether this path is correct for aarch64 under mac.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,124 @@
+all_jobs: &all_jobs
+  jobs:
+    - ios-armv7-release
+    - ios-armv7-debug
+    - ios-aarch64-release
+    - ios-aarch64-debug
+    - android-armv7-release
+    - android-armv7-debug
+    - android-aarch64-release
+    - android-aarch64-debug
+
+build_steps: &build_steps
+  steps:
+    - run:
+        name: Setup
+        command: |
+          PLATFORM=`uname`
+          if [ "${PLATFORM}" == "Darwin" ]; then
+            mkdir -p ~/cmake
+            curl -L https://cmake.org/files/v3.10/cmake-3.10.3-Darwin-x86_64.tar.gz | \
+                  tar -xz -C ~/cmake --strip-components 1
+            CMAKE_BIN_DIR="${HOME}/cmake/CMake.app/Contents/bin"
+            LOCAL_BIN_DIR="/usr/local/bin"
+            ln -s ${CMAKE_BIN_DIR}/cmake ${LOCAL_BIN_DIR}/cmake
+            ln -s ${CMAKE_BIN_DIR}/cpack ${LOCAL_BIN_DIR}/cpack
+            ln -s ${CMAKE_BIN_DIR}/ctest ${LOCAL_BIN_DIR}/ctest
+          else
+            NDK_VERSION="r16b"
+            sudo apt-get update
+            sudo apt-get install cmake
+            cd ${HOME}
+            curl -L https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip -o ndk.zip
+            unzip ndk.zip
+            mv android-ndk-${NDK_VERSION} android-ndk
+          fi
+    - checkout
+    - run:
+        name: Build
+        command: |
+          ./circle/build_${PLATFORM}.sh
+
+mac_build: &mac_build
+  macos:
+    xcode: "9.2.0"
+  <<: *build_steps
+
+linux_build: &linux_build
+  docker:
+    - image: circleci/buildpack-deps:bionic
+  <<: *build_steps
+
+# TODO(tom): release/debug variant
+# also clang variant for NDK
+# enable warnings as errors
+version: 2
+jobs:
+  ios-armv7-release:
+    <<: *mac_build
+    environment:
+      - PLATFORM: "ios"
+      - ARCH: "armv7"
+
+  ios-armv7-debug:
+    <<: *mac_build
+    environment:
+      - PLATFORM: "ios"
+      - ARCH: "armv7"
+      - DEBUG: "1"
+
+  ios-aarch64-release:
+    <<: *mac_build
+    environment:
+      - PLATFORM: "ios"
+      - ARCH: "aarch64"
+
+  ios-aarch64-debug:
+    <<: *mac_build
+    environment:
+      - PLATFORM: "ios"
+      - ARCH: "aarch64"
+      - DEBUG: "1"
+
+  android-armv7-release:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "android"
+      - ARCH: "armv7"
+
+  android-armv7-debug:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "android"
+      - ARCH: "armv7"
+      - DEBUG: "1"
+
+  android-aarch64-release:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "android"
+      - ARCH: "aarch64"
+
+  android-aarch64-debug:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "android"
+      - ARCH: "aarch64"
+      - DEBUG: "1"
+
+workflows:
+  version: 2
+  continous:
+    <<: *all_jobs
+
+  nightly:
+    <<: *all_jobs
+    triggers:
+      - schedule:
+          cron: "0 8 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - circleci
+

--- a/circle/build_android.sh
+++ b/circle/build_android.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+export ANDROID_NDK=${HOME}/android-ndk
+export NE10_ANDROID_TARGET_ARCH=${ARCH:-armv7}
+BUILD_DEBUG=${DEBUG:-0}
+
+TEST_TYPES="
+  -DNE10_SMOKE_TEST=ON \
+  -DNE10_REGRESSION_TEST=ON \
+  -DNE10_PERFORMANCE_TEST=ON
+"
+for test_type in ${TEST_TYPES}; do
+  rm -rf build && mkdir build && pushd build
+  cmake \
+    -DCMAKE_TOOLCHAIN_FILE=../android/android_config.cmake \
+    -DNE10_BUILD_UNIT_TEST=ON \
+    -DBUILD_DEBUG=${BUILD_DEBUG} \
+    ${test_type} \
+    ..
+  VERBOSE=1 make -j8
+  popd
+done

--- a/circle/build_ios.sh
+++ b/circle/build_ios.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+export IOS_DEVELOPER_PATH=/Applications/Xcode.app/Contents/Developer
+export NE10_IOS_TARGET_ARCH=${ARCH:-armv7}
+BUILD_DEBUG=${DEBUG:-0}
+
+TEST_TYPES="
+  -DNE10_SMOKE_TEST=ON \
+  -DNE10_REGRESSION_TEST=ON \
+  -DNE10_PERFORMANCE_TEST=ON
+"
+for test_type in ${TEST_TYPES}; do
+  rm -rf build && mkdir build && pushd build
+  cmake \
+    -DCMAKE_TOOLCHAIN_FILE=../ios/ios_config.cmake \
+    -DNE10_BUILD_UNIT_TEST=ON \
+    -DBUILD_DEBUG=${BUILD_DEBUG} \
+    ${test_type} \
+    ..
+  VERBOSE=1 make -j8
+  popd
+done


### PR DESCRIPTION
Fixes the iOS and Android builds when using modern versions of Xcode (9.2) and the NDK (r16b). This should fix #187 and #189.

Also, this adds a CircleCI continuous integration build, both to verify these changes and make it easier to keep things up-to-date in the future. Here's what the build looks like in my account: https://circleci.com/gh/thughes/workflows/Ne10/tree/circleci

In order for CircleCI to automatically run against this repository (rather than just my fork), someone with write access to the project will need to sign in with their github account: https://circleci.com/gh/projectNe10, click on the "Add Projects" tab and click "Set up Project" next to the "Ne10" project. You'll also need to contact billing@circleci.com in order to get free access to the macOS build machines (open source projects get free access on request).