### PR TITLE
Add Linux build to CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## What’s Ne10?
 Ne10 is a library of common, useful functions that have been heavily optimised for ARM-based CPUs equipped with [NEON](https://www.arm.com/products/processors/technologies/neon.php) SIMD capabilities. It provides consistent, well-tested behaviour, allowing for painless integration into a wide variety of applications. The library currently focuses primarily around math, signal processing, image processing, and physics functions.
 
-## Building
+## Building [![CircleCI](https://circleci.com/gh/projectNe10/Ne10.svg?style=svg)](https://circleci.com/gh/projectNe10/Ne10)
 Out of the box, Ne10 supports the Linux, Android, and iOS platforms. For instructions on building Ne10 for these platforms, please consult the build instructions in [`building.md`](https://github.com/projectNe10/Ne10/tree/master/doc/building.md#building-ne10). It is possible to use the library on other platforms (or, indeed, “without a platform”), however you may have to fiddle with some of the build configuration files.
 
 Once Ne10 has been built, it can be linked against just like any other C library. To link C code against Ne10, for instance, the compiler must first be aware of Ne10's library and header files — those within `build/modules/` and `inc/`. To do this, these files can be copied to the standard directories used by compilation tools by running `make install`, or by installing Ne10 from a package manager. Following this, you can simply include `Ne10.h` in your C code, and ask the compiler to link against the `NE10` library (e.g. with `-lNE10`).

--- a/circle.yml
+++ b/circle.yml
@@ -8,14 +8,17 @@ all_jobs: &all_jobs
     - android-armv7-debug
     - android-aarch64-release
     - android-aarch64-debug
+    - linux-armv7-release
+    - linux-armv7-debug
+    - linux-aarch64-release
+    - linux-aarch64-debug
 
 build_steps: &build_steps
   steps:
     - run:
         name: Setup
         command: |
-          PLATFORM=`uname`
-          if [ "${PLATFORM}" == "Darwin" ]; then
+          if [ "${PLATFORM}" == "ios" ]; then
             mkdir -p ~/cmake
             curl -L https://cmake.org/files/v3.10/cmake-3.10.3-Darwin-x86_64.tar.gz | \
                   tar -xz -C ~/cmake --strip-components 1
@@ -24,7 +27,7 @@ build_steps: &build_steps
             ln -s ${CMAKE_BIN_DIR}/cmake ${LOCAL_BIN_DIR}/cmake
             ln -s ${CMAKE_BIN_DIR}/cpack ${LOCAL_BIN_DIR}/cpack
             ln -s ${CMAKE_BIN_DIR}/ctest ${LOCAL_BIN_DIR}/ctest
-          else
+          elif [ "${PLATFORM}" == "android" ]; then
             NDK_VERSION="r16b"
             sudo apt-get update
             sudo apt-get install cmake
@@ -32,6 +35,18 @@ build_steps: &build_steps
             curl -L https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux-x86_64.zip -o ndk.zip
             unzip ndk.zip
             mv android-ndk-${NDK_VERSION} android-ndk
+          else
+            sudo apt-get update
+            sudo apt-get install cmake
+            if [ "${ARCH}" == "armv7" ]; then
+              sudo apt-get install g++-arm-linux-gnueabihf
+            else
+              # gcc7 aarch64 fails due to this bug:
+              # https://bugs.launchpad.net/gcc-linaro/+bug/1759369
+              # sudo apt-get install g++-aarch64-linux-gnu
+              sudo apt-get install g++-8-aarch64-linux-gnu
+              sudo update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-8 1 --slave /usr/bin/aarch64-linux-gnu-g++ aarch64-linux-gnu-g++ /usr/bin/aarch64-linux-gnu-g++-8
+            fi
           fi
     - checkout
     - run:
@@ -103,6 +118,32 @@ jobs:
     <<: *linux_build
     environment:
       - PLATFORM: "android"
+      - ARCH: "aarch64"
+      - DEBUG: "1"
+
+  linux-armv7-release:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "linux"
+      - ARCH: "armv7"
+
+  linux-armv7-debug:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "linux"
+      - ARCH: "armv7"
+      - DEBUG: "1"
+
+  linux-aarch64-release:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "linux"
+      - ARCH: "aarch64"
+
+  linux-aarch64-debug:
+    <<: *linux_build
+    environment:
+      - PLATFORM: "linux"
       - ARCH: "aarch64"
       - DEBUG: "1"
 

--- a/circle/build_linux.sh
+++ b/circle/build_linux.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+export NE10_LINUX_TARGET_ARCH=${ARCH:-armv7}
+BUILD_DEBUG=${DEBUG:-0}
+
+TEST_TYPES="
+  -DNE10_SMOKE_TEST=ON \
+  -DNE10_REGRESSION_TEST=ON \
+  -DNE10_PERFORMANCE_TEST=ON
+"
+for test_type in ${TEST_TYPES}; do
+  rm -rf build && mkdir build && pushd build
+  cmake \
+    -DCMAKE_TOOLCHAIN_FILE=../GNUlinux_config.cmake \
+    -DBUILD_DEBUG=${BUILD_DEBUG} \
+    ${test_type} \
+    ..
+  VERBOSE=1 make -j8
+  popd
+done

--- a/modules/imgproc/NE10_boxfilter.c
+++ b/modules/imgproc/NE10_boxfilter.c
@@ -368,7 +368,7 @@ void ne10_img_boxfilter_rgba8888_c (const ne10_uint8_t *src,
     if (!dst_buf)
     {
         fprintf (stderr,
-                 "ERROR: buffer allocation fails!\nallocation size: %d\n",
+                 "ERROR: buffer allocation fails!\nallocation size: %lu\n",
                  sizeof (ne10_uint8_t) *
                  src_sz.x *
                  src_sz.y *

--- a/modules/imgproc/NE10_boxfilter.neon.c
+++ b/modules/imgproc/NE10_boxfilter.neon.c
@@ -274,7 +274,7 @@ void ne10_img_boxfilter_col_neon (const ne10_uint8_t *src,
     if (!sum_row)
     {
         fprintf (stderr,
-                 "ERROR: buffer allocation fails!\nallocation size: %d\n",
+                 "ERROR: buffer allocation fails!\nallocation size: %lu\n",
                  sizeof (ne10_uint32_t) *
                  src_sz.x *
                  RGBA_CH);


### PR DESCRIPTION
Adds a Linux Linaro toolchain build to the CircleCI jobs. Also fixes the 64-bit Linux compile (incorrect `fprintf` format specifier).