### PR TITLE
Fix ASM issues building for Android using clang NDK r16b-r18b

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,12 +106,6 @@ endif(BUILD_DEBUG)
 set(NE10_ASM_OPTIMIZATION off)
 
 if(ANDROID_PLATFORM)
-    if(NE10_ARM_HARD_FLOAT)
-        set(FLOAT_ABI "hard")
-    else()
-        set(FLOAT_ABI "softfp")
-    endif()
-
     #TODO: Fine tune pic and pie flag for executable, share library and static library.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --sysroot=${NDK_SYSROOT_PATH} -pie")
     string(APPEND CMAKE_C_FLAGS " -isysroot ${NDK_ISYSROOT_PATH}")
@@ -119,7 +113,7 @@ if(ANDROID_PLATFORM)
 
     # Adding cflags for armv7. Aarch64 does not need such flags.
     if(${NE10_TARGET_ARCH} STREQUAL "armv7")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb -march=armv7-a -mfloat-abi=${FLOAT_ABI} -mfpu=vfp3")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb -march=armv7-a -mfloat-abi=softfp -mfpu=vfp3 -fno-integrated-as")
         if(NE10_ARM_HARD_FLOAT)
             # "--no-warn-mismatch" is needed for linker to suppress linker error about not all functions use VFP register to pass argument, eg.
             #   .../arm-linux-androideabi/bin/ld: error: ..../test-float.o

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -32,7 +32,7 @@ include_directories (
 
 file(GLOB SAMPLE_SOURCE_FILES "${PROJECT_SOURCE_DIR}/samples/*.c")
 
-if(NE10_BUILD_SHARED)
+if(NE10_BUILD_SHARED AND NE10_BUILD_UNIT_TEST)
     add_executable(NE10_test_dynamic ${SAMPLE_SOURCE_FILES})
     target_link_libraries (
         NE10_test_dynamic
@@ -41,7 +41,7 @@ if(NE10_BUILD_SHARED)
     )
 endif()
 
-if(NE10_BUILD_STATIC)
+if(NE10_BUILD_STATIC AND NE10_BUILD_UNIT_TEST)
     add_executable(NE10_test_static ${SAMPLE_SOURCE_FILES})
     target_link_libraries (
         NE10_test_static


### PR DESCRIPTION
This issue will fix https://github.com/projectNe10/Ne10/issues/131 and related ones: 

Removed `hard` mfloat-abi, use softfp instead:
https://android.googlesource.com/platform/ndk/+/ndk-r12-release/docs/HardFloatAbi.md

Added `-fno-integrated-as`:
https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md

