### PR TITLE
Resolve Android build issue and resolve warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ elseif(IOS_PLATFORM)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -miphoneos-version-min=" ${MIN_IOS_VER})
     set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -mfpu=neon -miphoneos-version-min=" ${MIN_IOS_VER})
 
-    if(${NE10_TARGET_ARCH} STREQUAL "armv7")
+    if("${NE10_TARGET_ARCH}" STREQUAL "armv7")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp3 -arch armv7 -arch armv7s")
         set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -arch armv7 -arch armv7s")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,13 +112,14 @@ if(ANDROID_PLATFORM)
         set(FLOAT_ABI "softfp")
     endif()
 
-    #TODO: Fine tune pic and pie flag for executable, share library and static library.
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --sysroot=${NDK_SYSROOT_PATH} -pie")
-    string(APPEND CMAKE_C_FLAGS " -isysroot ${NDK_ISYSROOT_PATH}")
-    add_definitions(-D__ANDROID_API__=${ANDROID_API_LEVEL})
+    # This section is causing build issues by redefining __ANDROID_API__
+    #    #TODO: Fine tune pic and pie flag for executable, share library and static library.
+    #    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --sysroot=${NDK_SYSROOT_PATH} -pie")
+    #    string(APPEND CMAKE_C_FLAGS " -isysroot ${NDK_ISYSROOT_PATH}")
+    #    add_definitions(-D__ANDROID_API__=${ANDROID_API_LEVEL})
 
     # Adding cflags for armv7. Aarch64 does not need such flags.
-    if(${NE10_TARGET_ARCH} STREQUAL "armv7")
+    if("${NE10_TARGET_ARCH}" STREQUAL "armv7")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mthumb -march=armv7-a -mfloat-abi=${FLOAT_ABI} -mfpu=vfp3")
         if(NE10_ARM_HARD_FLOAT)
             # "--no-warn-mismatch" is needed for linker to suppress linker error about not all functions use VFP register to pass argument, eg.

--- a/inc/NE10_types.h
+++ b/inc/NE10_types.h
@@ -192,7 +192,7 @@ static inline void createColumnMajorMatrix4x4 (ne10_mat4x4f_t * outMat, ne10_flo
         ne10_float32_t m13, ne10_float32_t m23, ne10_float32_t m33, ne10_float32_t m43,
         ne10_float32_t m14, ne10_float32_t m24, ne10_float32_t m34, ne10_float32_t m44)
 {
-    assert (0 != outMat);
+    assert (outMat != nullptr);
 
     outMat->c1.r1 = m11;
     outMat->c1.r2 = m21;

--- a/inc/NE10_types.h
+++ b/inc/NE10_types.h
@@ -126,7 +126,7 @@ typedef struct
 
 static inline void createColumnMajorMatrix2x2 (ne10_mat2x2f_t * outMat, ne10_float32_t m11, ne10_float32_t m21, ne10_float32_t m12, ne10_float32_t m22)
 {
-    assert (outMat != 0);
+    assert (outMat != nullptr);
 
     outMat->c1.r1 = m11;
     outMat->c1.r2 = m21;

--- a/inc/NE10_types.h
+++ b/inc/NE10_types.h
@@ -126,7 +126,7 @@ typedef struct
 
 static inline void createColumnMajorMatrix2x2 (ne10_mat2x2f_t * outMat, ne10_float32_t m11, ne10_float32_t m21, ne10_float32_t m12, ne10_float32_t m22)
 {
-    assert (0 != outMat);
+    assert (outMat != 0);
 
     outMat->c1.r1 = m11;
     outMat->c1.r2 = m21;
@@ -154,7 +154,7 @@ static inline void createColumnMajorMatrix3x3 (ne10_mat3x3f_t * outMat, ne10_flo
         ne10_float32_t m12, ne10_float32_t m22, ne10_float32_t m32,
         ne10_float32_t m13, ne10_float32_t m23, ne10_float32_t m33)
 {
-    assert (0 != outMat);
+    assert (outMat != nullptr);
 
     outMat->c1.r1 = m11;
     outMat->c1.r2 = m21;


### PR DESCRIPTION
We were getting build failures on Android because this part of the script was redefining `__ANDROID_API__`. 

Is this the best solution? There was a TODO left here, I don't really understand the context of it, so is there something else to do here? If this is no longer needed should this section be deleted? 

Also resolving a  [-Wzero-as-null-pointer-constant] type warning. 