### PR TITLE
[FIX] fix error in header prototype

### DIFF
--- a/modules/dsp/NE10_fft_generic_int32.h
+++ b/modules/dsp/NE10_fft_generic_int32.h
@@ -73,7 +73,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 template<int RADIX>
 inline void FFT_MUL_TW (ne10_fft_cpx_int32_t out[RADIX],
         const ne10_fft_cpx_int32_t in[RADIX],
-        const ne10_fft_cpx_int32_t tw[RADIX]);
+        const ne10_fft_cpx_int32_t tw[RADIX-1]);
 
 template<>
 inline void FFT_MUL_TW<2> (ne10_fft_cpx_int32_t out[2],


### PR DESCRIPTION
building with clang you can see error like:

Ne10/modules/dsp/NE10_fft_generic_int32.h:81:36: error: argument 'tw' of type 'const ne10_fft_cpx_int32_t[1]' with mismatched bound [-Werror,-Warray-parameter]
        const ne10_fft_cpx_int32_t tw[1])
                                   ^
Ne10/modules/dsp/NE10_fft_generic_int32.h:76:36: note: previously declared as 'const ne10_fft_cpx_int32_t[2]' here
        const ne10_fft_cpx_int32_t tw[RADIX]);